### PR TITLE
feat(projects): Kundenprojekte über data-mode-Filter freischalten

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1666,6 +1666,35 @@ html[data-color-scheme="light"] .hero-section--single .slide-description {
     opacity: 0.85;
 }
 
+/* Both decks stay in the DOM; [hidden] is what takes them off stage. The
+   display rules above would otherwise win over the UA [hidden] default. */
+.project-pag-btn[hidden],
+.project-card[hidden] {
+    display: none !important;
+}
+
+.project-mode-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.35rem;
+    height: 1.35rem;
+    padding: 0 0.35rem;
+    border-radius: var(--radius-full);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    transition: color var(--duration-base) var(--ease-out),
+                background var(--duration-base) var(--ease-out);
+}
+
+.project-mode-btn.is-active .project-mode-count {
+    background: rgba(var(--theme-primary), 0.18);
+    color: rgb(var(--theme-primary));
+}
+
 .project-mode-status {
     position: absolute;
     width: 1px;
@@ -1688,6 +1717,168 @@ html[data-color-scheme="light"] .hero-section--single .slide-description {
 
     .projects-section .container .section-header + .project-mode-selector {
         width: 100%;
+    }
+}
+
+/* ═══ ALL PROJECTS GRID ═══
+   The full index under the slider. The slider carries the highlights with a
+   screenshot each; this grid guarantees nothing is missing. Same mode filter
+   as the slider, so the two always show the same category. */
+.all-projects {
+    margin-top: var(--space-3xl);
+    padding-top: var(--space-2xl);
+    border-top: 1px solid var(--color-border);
+    position: relative;
+    z-index: 5;
+}
+
+.all-projects__head {
+    margin-bottom: var(--space-xl);
+    text-align: center;
+}
+
+.all-projects__title {
+    font-size: var(--font-size-2xl);
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 var(--space-xs);
+}
+
+.all-projects__hint {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+}
+
+.project-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-md);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.project-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: var(--space-md);
+    min-height: 100%;
+    padding: var(--space-lg);
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    transition: border-color var(--duration-base) var(--ease-out),
+                background var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-out);
+}
+
+.project-card:hover {
+    background: var(--color-bg-card-hover);
+    border-color: rgba(var(--theme-primary), 0.4);
+    transform: translateY(-2px);
+}
+
+.project-card__link {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    color: inherit;
+    text-decoration: none;
+}
+
+.project-card__name {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--color-text);
+    transition: color var(--duration-base) var(--ease-out);
+}
+
+/* Cards without a public link are plain divs — no affordance, no hover cue. */
+a.project-card__link .project-card__name::after {
+    content: '↗';
+    margin-left: 0.4em;
+    font-size: 0.8em;
+    color: var(--color-text-muted);
+    transition: color var(--duration-base) var(--ease-out);
+}
+
+.project-card:hover a.project-card__link .project-card__name,
+.project-card:hover a.project-card__link .project-card__name::after {
+    color: rgb(var(--theme-primary));
+}
+
+.project-card__desc {
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+}
+
+.project-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+}
+
+.project-card__stack {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+}
+
+.project-card__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: var(--radius-full);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.project-card__status::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.project-card__status.is-live {
+    background: rgba(34, 197, 94, 0.12);
+    color: #4ade80;
+}
+
+.project-card__status.is-done {
+    background: rgba(var(--theme-primary), 0.12);
+    color: rgb(var(--theme-primary));
+}
+
+.project-card__status.is-wip {
+    background: rgba(234, 179, 8, 0.12);
+    color: #facc15;
+}
+
+html[data-color-scheme="light"] .project-card__status.is-live {
+    color: #15803d;
+}
+
+html[data-color-scheme="light"] .project-card__status.is-wip {
+    color: #a16207;
+}
+
+@media (max-width: 600px) {
+    .project-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .all-projects {
+        margin-top: var(--space-2xl);
     }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -78,6 +78,41 @@
             'projects.mode.customers': 'Kundenprojekte',
             'projects.mode.customers.lock': 'Bald verfügbar',
             'projects.mode.own': 'Eigene Projekte',
+            // Alle-Projekte-Grid
+            'projects.all.title': 'Alle Projekte',
+            'projects.all.hint': 'Vollständige Übersicht — die Auswahl folgt dem Modus oben.',
+            'grid.status.live': 'Live',
+            'grid.status.done': 'Fertig',
+            'grid.status.wip': 'In Arbeit',
+            'grid.coha.desc': 'Vietnamesisches Restaurant in Bruckmühl — Speisekarte, Galerie, Reservierung.',
+            'grid.imkerei.desc': 'Honig-Onlineshop der Familienimkerei aus Elchingen.',
+            'grid.jkentertainment.desc': 'TCG-Onlineshop mit über 4.000 Artikeln, zwei Stores in Frankfurt und Darmstadt.',
+            'grid.kayaseeds.desc': 'E-Commerce für eine bayerische Cannabis-Samenmarke.',
+            'grid.danielbrecheis.desc': 'Human Bridges Consulting — HR-Coaching, Workshops, Interim-Management.',
+            'grid.soundoflvke.desc': 'Künstler-Website mit Audio-Player und Release-Übersicht.',
+            'grid.casteldelmonte.desc': 'Italienisches Restaurant in Vagen — Karte, Öffnungszeiten, Kontakt.',
+            'grid.kaess.desc': 'Lackschadenfreie Dellenreparatur — Leistungen, Ablauf, Galerie, Kontakt.',
+            'grid.wkdk.desc': 'Ankauf-Plattform für Sammelkarten — Collectibles-Hub GmbH, Rosenheim.',
+            'grid.bbspiele.desc': 'Marketing-Website für den Spiele- und Collectibles-Händler aus Rosenheim.',
+            'grid.nolte.desc': 'Markenauftritt für Klassiker-Fahrzeuge.',
+            'grid.jaeggl.desc': 'Redesign eines bestehenden Firmenauftritts.',
+            'grid.e46.desc': 'Desktop-App für BMW E46 Steuergeräte-Coding über serielle Schnittstelle.',
+            'grid.aicaptain.desc': 'KI-Agent als VS Code Extension — Code-Generierung, Debugging, Review.',
+            'grid.medieval.desc': 'Browser-Strategiespiel im Mittelalter-Setting mit eigenem Wave-System.',
+            'grid.shookroko.desc': 'Action-Browsergame mit Phaser 3, eigener Game-Loop und Asset-Pipeline.',
+            'grid.e46viola.desc': 'Fahrzeug-Showcase aus dem E46-Umfeld.',
+            'grid.teamkickoff.desc': 'Interaktives Meeting-Board für neun Personen mit geteiltem Zustand.',
+            'grid.dogkennel.desc': 'Plattform für Hundepensionen — Buchungen, Belegung, Hunde- und Halterprofile.',
+            'grid.teahop.desc': 'Bio-Tee-Shop als eigenes Shopify-Theme, Online Store 2.0.',
+            'grid.teekompass.desc': 'Bio-Tee-Abo mit KI-Personalisierung: Box, Bewertung, bessere nächste Box.',
+            'grid.glowcan.desc': '3D-gedruckter LED-Deckel für Energy-Dosen — Shopify-Theme, mobile-first.',
+            'grid.bierbrauen.desc': 'Web-App rund ums Bierbrauen — Rezepte und Prozessbegleitung.',
+            'grid.albert.desc': 'Evolutionssimulation mit neuronalen Netzen, plus 3D-Battle-Royale-Ableger.',
+            'grid.kundenkalender.desc': 'Lokaler Terminkalender als Desktop-App — Serientermine, ICS/CSV-Export.',
+            'grid.maxorchester.desc': 'Orchestrierung mehrerer KI-Agenten über ein gemeinsames Frontend.',
+            'grid.vibeide.desc': 'Experimentelle Entwicklungsumgebung mit KI-gestütztem Workflow.',
+            'grid.moneydash.desc': 'Dashboard für Finanzdaten und Auswertungen.',
+            'grid.assetkit.desc': 'Toolchain für Spiel-Assets — Generierung, Freistellen, Normalisierung.',
             'about.title': 'Über mich',
             'about.eyebrow': 'Persönlich',
             'about.imageAlt': 'Maximilian Haak vor seinem BMW E46 mit Alpenpanorama',
@@ -324,6 +359,41 @@
             'projects.mode.customers': 'Customer projects',
             'projects.mode.customers.lock': 'Coming soon',
             'projects.mode.own': 'Own projects',
+            // All-projects grid
+            'projects.all.title': 'All projects',
+            'projects.all.hint': 'Full overview — follows the mode selected above.',
+            'grid.status.live': 'Live',
+            'grid.status.done': 'Shipped',
+            'grid.status.wip': 'In progress',
+            'grid.coha.desc': 'Vietnamese restaurant in Bruckmühl — menu, gallery, reservations.',
+            'grid.imkerei.desc': 'Honey online shop for the Feuerstein family apiary in Elchingen.',
+            'grid.jkentertainment.desc': 'TCG online store with 4,000+ items and two stores in Frankfurt and Darmstadt.',
+            'grid.kayaseeds.desc': 'E-commerce for a Bavarian cannabis seed brand.',
+            'grid.danielbrecheis.desc': 'Human Bridges Consulting — HR coaching, workshops, interim management.',
+            'grid.soundoflvke.desc': 'Artist website with audio player and release overview.',
+            'grid.casteldelmonte.desc': 'Italian restaurant in Vagen — menu, opening hours, contact.',
+            'grid.kaess.desc': 'Paintless dent repair — services, process, gallery, contact.',
+            'grid.wkdk.desc': 'Trading card buy-back platform — Collectibles-Hub GmbH, Rosenheim.',
+            'grid.bbspiele.desc': 'Marketing site for the games and collectibles retailer in Rosenheim.',
+            'grid.nolte.desc': 'Brand presence for classic cars.',
+            'grid.jaeggl.desc': 'Redesign of an existing company website.',
+            'grid.e46.desc': 'Desktop app for BMW E46 ECU coding over a serial interface.',
+            'grid.aicaptain.desc': 'AI agent as a VS Code extension — code generation, debugging, review.',
+            'grid.medieval.desc': 'Browser strategy game in a medieval setting with a custom wave system.',
+            'grid.shookroko.desc': 'Action browser game built with Phaser 3, custom game loop and asset pipeline.',
+            'grid.e46viola.desc': 'Vehicle showcase from the E46 world.',
+            'grid.teamkickoff.desc': 'Interactive meeting board for nine people with shared state.',
+            'grid.dogkennel.desc': 'Platform for dog boarding kennels — bookings, occupancy, dog and owner profiles.',
+            'grid.teahop.desc': 'Organic tea shop as a custom Shopify theme, Online Store 2.0.',
+            'grid.teekompass.desc': 'Organic tea subscription with AI personalisation: box, rating, better next box.',
+            'grid.glowcan.desc': '3D-printed LED lid for energy drink cans — Shopify theme, mobile-first.',
+            'grid.bierbrauen.desc': 'Web app for home brewing — recipes and process guidance.',
+            'grid.albert.desc': 'Evolution simulation with neural networks, plus a 3D battle royale spin-off.',
+            'grid.kundenkalender.desc': 'Local appointment calendar as a desktop app — recurring events, ICS/CSV export.',
+            'grid.maxorchester.desc': 'Orchestrating multiple AI agents through a shared frontend.',
+            'grid.vibeide.desc': 'Experimental development environment with an AI-assisted workflow.',
+            'grid.moneydash.desc': 'Dashboard for financial data and analysis.',
+            'grid.assetkit.desc': 'Toolchain for game assets — generation, background removal, normalisation.',
             'about.title': 'About me',
             'about.eyebrow': 'Personal',
             'about.imageAlt': 'Maximilian Haak in front of his BMW E46 with an alpine backdrop',
@@ -707,22 +777,34 @@
             this.section = document.querySelector('#projects');
             if (!this.section) return;
 
-            this.slides = Array.from(this.section.querySelectorAll('.hero-slide'));
+            this.allSlides = Array.from(this.section.querySelectorAll('.hero-slide'));
             // Exclude any locked/disabled mode buttons (e.g. .project-mode-btn)
             // and any nav button explicitly marked disabled or aria-disabled.
-            this.navBtns = Array.from(this.section.querySelectorAll('.project-nav-btn'))
+            this.allNavBtns = Array.from(this.section.querySelectorAll('.project-nav-btn'))
                 .filter(btn => !btn.disabled && btn.getAttribute('aria-disabled') !== 'true');
 
             // Re-sort slides to match nav button order (data-project ↔ data-theme)
             // so that index-based pairing in goToSlide() stays in sync after the
             // nav has been grouped/re-ordered visually.
-            const slideByTheme = new Map(this.slides.map(s => [s.getAttribute('data-theme'), s]));
-            const ordered = this.navBtns
+            const slideByTheme = new Map(this.allSlides.map(s => [s.getAttribute('data-theme'), s]));
+            const ordered = this.allNavBtns
                 .map(btn => slideByTheme.get(btn.getAttribute('data-project')))
                 .filter(Boolean);
-            if (ordered.length === this.slides.length) {
-                this.slides = ordered;
+            if (ordered.length === this.allSlides.length) {
+                this.allSlides = ordered;
             }
+
+            // Mode ("customers" / "own") splits the same slider into two decks.
+            // Slides and nav buttons stay in the DOM; only the active deck is
+            // wired into this.slides/this.navBtns, so every index-based method
+            // below keeps working unchanged.
+            this.modeBtns = Array.from(this.section.querySelectorAll('.project-mode-btn'));
+            this.gridCards = Array.from(this.section.querySelectorAll('.project-card'));
+            const activeModeBtn = this.modeBtns.find(btn => btn.classList.contains('is-active'));
+            this.mode = activeModeBtn ? activeModeBtn.getAttribute('data-mode') : 'own';
+            this.slides = [];
+            this.navBtns = [];
+            this.applyMode(this.mode, { initial: true });
             this.arrowLeft = this.section.querySelector('.slider-arrow-left');
             this.arrowRight = this.section.querySelector('.slider-arrow-right');
             this.slidesContainer = this.section.querySelector('.hero-slides-container');
@@ -745,6 +827,66 @@
             this.bindEvents();
             this.setActiveSlide(this.currentIndex, { dispatchEvent: false });
             this.syncToTheme(themeController.getProjectTheme(), { animate: false });
+        }
+
+        getModeOf(el) {
+            return el.getAttribute('data-mode') || 'own';
+        }
+
+        applyMode(mode, options = {}) {
+            const { initial = false, keepTheme = false } = options;
+            this.mode = mode;
+
+            this.slides = this.allSlides.filter(slide => this.getModeOf(slide) === mode);
+            this.navBtns = this.allNavBtns.filter(btn => this.getModeOf(btn) === mode);
+            if (this.slides.length === 0) return;
+
+            this.allSlides.forEach(slide => {
+                if (this.slides.includes(slide)) return;
+                this.resetSlideInlineState(slide);
+                slide.classList.remove('active');
+                slide.hidden = true;
+            });
+
+            this.allNavBtns.forEach(btn => {
+                const inMode = this.navBtns.includes(btn);
+                btn.hidden = !inMode;
+                if (inMode) return;
+                btn.classList.remove('active');
+                btn.setAttribute('aria-selected', 'false');
+                btn.tabIndex = -1;
+            });
+
+            this.gridCards.forEach(card => {
+                card.hidden = this.getModeOf(card) !== mode;
+            });
+
+            this.modeBtns.forEach(btn => {
+                const isActive = btn.getAttribute('data-mode') === mode;
+                btn.classList.toggle('is-active', isActive);
+                btn.setAttribute('aria-pressed', String(isActive));
+            });
+
+            if (initial) return;
+
+            // A mode switch swaps the whole deck, so any in-flight slide
+            // transition is now animating elements that just left the stage.
+            this.isAnimating = false;
+            if (this.animationGuardTimer !== null) {
+                window.clearTimeout(this.animationGuardTimer);
+                this.animationGuardTimer = null;
+            }
+            this.currentIndex = 0;
+            // keepTheme: the caller already picked the colour it wants (e.g. a
+            // swatch for a slide in this deck) — landing on slide 0 must not
+            // clobber it on the way there.
+            this.setActiveSlide(0, { updateTheme: !keepTheme, themeSource: 'slider' });
+        }
+
+        setMode(mode) {
+            if (mode === this.mode) return;
+            if (!this.allSlides.some(slide => this.getModeOf(slide) === mode)) return;
+            this.applyMode(mode);
         }
 
         getSlideIndexForTheme(theme) {
@@ -814,7 +956,19 @@
         }
 
         syncToTheme(theme, options = {}) {
-            const index = this.getSlideIndexForTheme(theme);
+            let index = this.getSlideIndexForTheme(theme);
+
+            // The colour picker offers themes from both decks. If the chosen
+            // one lives in the deck that is currently hidden, switch modes
+            // first so the swatch still lands on its slide.
+            if (index === -1) {
+                const projectTheme = theme === 'maxhaak' ? 'e46' : theme;
+                const target = this.allSlides.find(slide => slide.getAttribute('data-theme') === projectTheme);
+                if (!target) return;
+                this.applyMode(this.getModeOf(target), { keepTheme: true });
+                index = this.getSlideIndexForTheme(theme);
+            }
+
             if (index === -1 || index === this.currentIndex) return;
 
             if (options.animate && this.isSectionVisible()) {
@@ -853,8 +1007,19 @@
         }
 
         bindEvents() {
-            this.navBtns.forEach((btn, i) => {
-                btn.addEventListener('click', () => this.goToSlide(i));
+            // Delegated: this.navBtns is rebuilt on every mode switch, so
+            // per-button listeners would point at stale indices.
+            if (this.pagination) {
+                this.pagination.addEventListener('click', (e) => {
+                    const btn = e.target.closest('.project-nav-btn');
+                    if (!btn) return;
+                    const index = this.navBtns.indexOf(btn);
+                    if (index !== -1) this.goToSlide(index);
+                });
+            }
+
+            this.modeBtns.forEach(btn => {
+                btn.addEventListener('click', () => this.setMode(btn.getAttribute('data-mode')));
             });
             document.addEventListener('project-theme:change', (e) => {
                 if (e.detail?.source !== 'picker') return;

--- a/index.html
+++ b/index.html
@@ -192,32 +192,288 @@
 
                 <div class="project-mode-selector" role="group" aria-label="Projekt-Kategorie">
                     <button type="button"
-                            class="project-mode-btn is-locked"
+                            class="project-mode-btn"
                             data-mode="customers"
-                            aria-disabled="true"
-                            disabled
-                            tabindex="-1"
-                            title="Bald verfügbar">
-                        <svg class="project-mode-lock" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                            <rect x="4" y="11" width="16" height="10" rx="2"/>
-                            <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
-                        </svg>
+                            aria-pressed="false">
                         <span class="project-mode-label" data-i18n="projects.mode.customers">Kundenprojekte</span>
-                        <span class="project-mode-status" data-i18n="projects.mode.customers.lock">Bald verfügbar</span>
+                        <span class="project-mode-count" aria-hidden="true">12</span>
                     </button>
                     <button type="button"
                             class="project-mode-btn is-active"
                             data-mode="own"
                             aria-pressed="true">
                         <span class="project-mode-label" data-i18n="projects.mode.own">Eigene Projekte</span>
+                        <span class="project-mode-count" aria-hidden="true">17</span>
                     </button>
                 </div>
             </div>
 
             <div class="hero-slides-container">
 
+                <!-- ══ KUNDENPROJEKTE ══ -->
+
+                <!-- Kunde 1: Co Ha -->
+                <div class="hero-slide" id="slide-coha" data-theme="coha" data-mode="customers" role="tabpanel" aria-labelledby="tab-coha" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.coha.t1">Restaurant-Site.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.coha.t2">Vietnamesisch.</span></span>
+                                <span class="title-line" data-i18n="slide.coha.t3">Tische gefüllt.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.coha.desc">Website für Co Ha, ein vietnamesisches Restaurant in Bruckmühl: Speisekarte, Galerie, Online-Reservierung und Google-Bewertungen. Gebaut mit Next.js — schnell, mobil-optimiert und konsequent auf Reservierungen ausgerichtet.</p>
+                            <div class="slide-cta">
+                                <a href="https://coha.vercel.app" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.coha.cta1">Live ansehen</a>
+                                <a href="projects/coha.html" class="btn btn-outline" data-i18n="slide.coha.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.coha.tag1">Next.js &amp; Vercel</span>
+                                <span class="slide-tag" data-i18n="slide.coha.tag2">Speisekarte &amp; Reservierung</span>
+                                <span class="slide-tag" data-i18n="slide.coha.tag3">Lokale SEO</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 2v7c0 1.1.9 2 2 2h2a2 2 0 0 0 2-2V2M6 2v9m0 0v11M18 2v20M18 11c2 0 3-1.5 3-4V2h-3"/></svg>
+                                    <span data-i18n="slide.coha.badge">KUNDENREFERENZ</span>
+                                </div>
+                                <a href="https://coha.vercel.app" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="Co Ha Website ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">coha.vercel.app</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/coha.webp" alt="Co Ha — vietnamesisches Restaurant" loading="lazy" decoding="async" width="1600" height="800">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Kunde 2: Imkerei Feuerstein -->
+                <div class="hero-slide" id="slide-imkerei" data-theme="imkerei" data-mode="customers" role="tabpanel" aria-labelledby="tab-imkerei" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.imkerei.t1">Honig-Shop.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.imkerei.t2">Familienimkerei.</span></span>
+                                <span class="title-line" data-i18n="slide.imkerei.t3">Online verkauft.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.imkerei.desc">Vollständiger Online-Shop für die Familienimkerei Feuerstein aus Elchingen: Produktkatalog mit Honig-Sorten, Warenkorb, News-Bereich und Kundenbewertungen. Gebaut mit Next.js, auf Vercel deployed — schnell, SEO-optimiert und responsiv auf allen Geräten.</p>
+                            <div class="slide-cta">
+                                <a href="https://imkerei-feuerstein.vercel.app" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.imkerei.cta1">Shop ansehen</a>
+                                <a href="projects/imkerei-feuerstein.html" class="btn btn-outline" data-i18n="slide.imkerei.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.imkerei.tag1">Next.js &amp; Vercel</span>
+                                <span class="slide-tag" data-i18n="slide.imkerei.tag2">E-Commerce</span>
+                                <span class="slide-tag" data-i18n="slide.imkerei.tag3">SEO &amp; Performance</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2l4 4-4 4-4-4 4-4zM12 10l4 4-4 4-4-4 4-4zM12 18l4 4-4-0-4 0 4-4z"/></svg>
+                                    <span data-i18n="slide.imkerei.badge">KUNDENPROJEKT</span>
+                                </div>
+                                <a href="https://imkerei-feuerstein.vercel.app" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="Imkerei Feuerstein Shop ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">imkerei-feuerstein.vercel.app</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/imkerei-feuerstein.webp" alt="Imkerei Feuerstein — Honig-Onlineshop" loading="lazy" decoding="async" width="1600" height="902">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Kunde 3: JK Entertainment -->
+                <div class="hero-slide" id="slide-jkentertainment" data-theme="jkentertainment" data-mode="customers" role="tabpanel" aria-labelledby="tab-jkentertainment" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.jkentertainment.t1">TCG-Shop.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.jkentertainment.t2">Magic, Pokémon</span></span>
+                                <span class="title-line" data-i18n="slide.jkentertainment.t3">&amp; mehr.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.jkentertainment.desc">JK Entertainment: Online-Shop für Trading Card Games (Magic, Pokémon, Yu-Gi-Oh! &amp; 6 weitere). Next.js Storefront, Produktkatalog mit über 4.000 Artikeln, Vorbestell-System und Community-Anbindung an zwei Stores in Frankfurt und Darmstadt.</p>
+                            <div class="slide-cta">
+                                <a href="https://jk-entertainment.vercel.app/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.jkentertainment.cta1">Live ansehen</a>
+                                <a href="projects/jkentertainment.html" class="btn btn-outline" data-i18n="slide.jkentertainment.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.jkentertainment.tag1">Next.js</span>
+                                <span class="slide-tag" data-i18n="slide.jkentertainment.tag2">E-Commerce</span>
+                                <span class="slide-tag" data-i18n="slide.jkentertainment.tag3">TCG</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="5" width="12" height="16" rx="2"/><path d="M9 3h9a2 2 0 0 1 2 2v12"/></svg>
+                                    <span data-i18n="slide.jkentertainment.badge">TCG STORE</span>
+                                </div>
+                                <a href="https://jk-entertainment.vercel.app/" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="JK Entertainment Shop ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">jk-entertainment.vercel.app</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/jkentertainment.webp" alt="JK Entertainment — TCG Online-Shop" loading="lazy" decoding="async" width="1600" height="800">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Kunde 4: Kaya Seeds -->
+                <div class="hero-slide" id="slide-kayaseeds" data-theme="kayaseeds" data-mode="customers" role="tabpanel" aria-labelledby="tab-kayaseeds" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.kayaseeds.t1">Premium.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.kayaseeds.t2">Cannabis</span></span>
+                                <span class="title-line" data-i18n="slide.kayaseeds.t3">Seeds.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.kayaseeds.desc">Kaya Seeds: E-Commerce-Website für eine bayerische Cannabis-Samenmarke. Editoriales Layout, Produkt-Grid, Warenkorb-Flow und ein Markenauftritt zwischen 70er-Vibe und moderner Frische.</p>
+                            <div class="slide-cta">
+                                <a href="https://kayaseeds.vercel.app/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.kayaseeds.cta1">Live ansehen</a>
+                                <a href="projects/kayaseeds.html" class="btn btn-outline" data-i18n="slide.kayaseeds.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.kayaseeds.tag1">E-Commerce</span>
+                                <span class="slide-tag" data-i18n="slide.kayaseeds.tag2">Branding</span>
+                                <span class="slide-tag" data-i18n="slide.kayaseeds.tag3">Shopify</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 2l1.5 3h9L18 2M3 7h18l-1.5 13a2 2 0 0 1-2 2h-11a2 2 0 0 1-2-2z"/></svg>
+                                    <span data-i18n="slide.kayaseeds.badge">ONLINE-SHOP</span>
+                                </div>
+                                <a href="https://kayaseeds.vercel.app/" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="Kaya Seeds Website ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">kayaseeds.vercel.app</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/kayaseeds.webp" alt="Kaya Seeds — Cannabis-Samen Onlineshop" loading="lazy" decoding="async" width="1600" height="774">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Kunde 5: Daniel Brecheis -->
+                <div class="hero-slide" id="slide-danielbrecheis" data-theme="danielbrecheis" data-mode="customers" role="tabpanel" aria-labelledby="tab-danielbrecheis" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.danielbrecheis.t1">HR Coaching.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.danielbrecheis.t2">Human</span></span>
+                                <span class="title-line" data-i18n="slide.danielbrecheis.t3">Bridges.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.danielbrecheis.desc">Daniel Brecheis — Human Bridges Consulting: Markenwebsite für HR-Coaching, Workshops und Interim-Management. Klare Typografie, ruhige Bildsprache und ein wertiges Erscheinungsbild für 25+ Jahre HR-Erfahrung.</p>
+                            <div class="slide-cta">
+                                <a href="https://danielbrecheis.vercel.app/" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.danielbrecheis.cta1">Live ansehen</a>
+                                <a href="projects/danielbrecheis.html" class="btn btn-outline" data-i18n="slide.danielbrecheis.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.danielbrecheis.tag1">Coaching</span>
+                                <span class="slide-tag" data-i18n="slide.danielbrecheis.tag2">Branding</span>
+                                <span class="slide-tag" data-i18n="slide.danielbrecheis.tag3">Vercel</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>
+                                    <span data-i18n="slide.danielbrecheis.badge">CONSULTING</span>
+                                </div>
+                                <a href="https://danielbrecheis.vercel.app/" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="Daniel Brecheis Website ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">danielbrecheis.vercel.app</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/danielbrecheis.webp" alt="Daniel Brecheis — Human Bridges Consulting" loading="lazy" decoding="async" width="1600" height="802">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Kunde 6: Sound of Lvke -->
+                <div class="hero-slide" id="slide-soundoflvke" data-theme="soundoflvke" data-mode="customers" role="tabpanel" aria-labelledby="tab-soundoflvke" hidden>
+                    <div class="slide-content">
+                        <div class="slide-text">
+                            <h2 class="slide-title">
+                                <span class="title-line" data-i18n="slide.soundoflvke.t1">Sound.</span>
+                                <span class="title-line"><span class="gradient-text" data-i18n="slide.soundoflvke.t2">Design.</span></span>
+                                <span class="title-line" data-i18n="slide.soundoflvke.t3">Identität.</span>
+                            </h2>
+                            <p class="slide-description" data-i18n="slide.soundoflvke.desc">Portfolio-Website für einen Musik-Künstler — integrierter Audio-Player, Release-Übersicht und individuelles responsive Design. Kreative Webentwicklung, die Marken zum Leben erweckt.</p>
+                            <div class="slide-cta">
+                                <a href="https://soundoflvke.github.io" target="_blank" rel="noopener noreferrer" class="btn btn-primary" data-i18n="slide.soundoflvke.cta1">Live ansehen</a>
+                                <a href="projects/soundoflvke.html" class="btn btn-outline" data-i18n="slide.soundoflvke.cta2">Projekt-Details</a>
+                            </div>
+                            <div class="slide-tags">
+                                <span class="slide-tag" data-i18n="slide.soundoflvke.tag1">Künstler-Branding</span>
+                                <span class="slide-tag" data-i18n="slide.soundoflvke.tag2">Audio Integration</span>
+                                <span class="slide-tag" data-i18n="slide.soundoflvke.tag3">Responsive Design</span>
+                            </div>
+                        </div>
+                        <div class="slide-visual">
+                            <div class="showcase-container">
+                                <div class="showcase-badge">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+                                    <span data-i18n="slide.soundoflvke.badge">KÜNSTLER-WEBSITE</span>
+                                </div>
+                                <a href="https://soundoflvke.github.io" target="_blank" rel="noopener noreferrer" class="showcase-link" aria-label="Sound of Lvke Website ansehen"><div class="showcase-frame">
+                                    <div class="browser-bar">
+                                        <span class="dot red"></span>
+                                        <span class="dot yellow"></span>
+                                        <span class="dot green"></span>
+                                        <span class="browser-url">soundoflvke.github.io</span>
+                                    </div>
+                                    <div class="showcase-image-wrap">
+                                        <img src="assets/img/projects/soundoflvke.webp" alt="Sound of Lvke — Künstler-Website" loading="lazy" decoding="async" width="1600" height="798">
+                                    </div>
+                                </div></a>
+                                <div class="showcase-glow"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ══ EIGENE PROJEKTE ══ -->
+
                 <!-- Slide 1: E46 Studio -->
-                <div class="hero-slide active" id="slide-e46" data-theme="e46" role="tabpanel" aria-labelledby="tab-e46">
+                <div class="hero-slide active" id="slide-e46" data-theme="e46" data-mode="own" role="tabpanel" aria-labelledby="tab-e46">
                     <div class="slide-content">
                         <div class="slide-text">
                             <h2 class="slide-title">
@@ -260,7 +516,7 @@
                 </div>
 
                 <!-- Slide 2: AI Captain -->
-                <div class="hero-slide" id="slide-aicaptain" data-theme="aicaptain" role="tabpanel" aria-labelledby="tab-aicaptain" hidden>
+                <div class="hero-slide" id="slide-aicaptain" data-theme="aicaptain" data-mode="own" role="tabpanel" aria-labelledby="tab-aicaptain" hidden>
                     <div class="slide-content">
                         <div class="slide-text">
                             <h2 class="slide-title">
@@ -303,7 +559,7 @@
                 </div>
 
                 <!-- Slide 3: Medieval Tower Defense -->
-                <div class="hero-slide" id="slide-medieval" data-theme="medieval" role="tabpanel" aria-labelledby="tab-medieval" hidden>
+                <div class="hero-slide" id="slide-medieval" data-theme="medieval" data-mode="own" role="tabpanel" aria-labelledby="tab-medieval" hidden>
                     <div class="slide-content">
                         <div class="slide-text">
                             <h2 class="slide-title">
@@ -346,7 +602,7 @@
                 </div>
 
                 <!-- Slide 4: Shookroko -->
-                <div class="hero-slide" id="slide-shookroko" data-theme="shookroko" role="tabpanel" aria-labelledby="tab-shookroko" hidden>
+                <div class="hero-slide" id="slide-shookroko" data-theme="shookroko" data-mode="own" role="tabpanel" aria-labelledby="tab-shookroko" hidden>
                     <div class="slide-content">
                         <div class="slide-text">
                             <h2 class="slide-title">
@@ -389,7 +645,7 @@
                 </div>
 
                 <!-- Slide 5: dog-kennel-online -->
-                <div class="hero-slide" id="slide-dogkennel" data-theme="dogkennel" role="tabpanel" aria-labelledby="tab-dogkennel" hidden>
+                <div class="hero-slide" id="slide-dogkennel" data-theme="dogkennel" data-mode="own" role="tabpanel" aria-labelledby="tab-dogkennel" hidden>
                     <div class="slide-content">
                         <div class="slide-text">
                             <h2 class="slide-title">
@@ -445,27 +701,355 @@
 
             <div class="container">
                 <nav class="project-pagination" role="tablist" aria-label="Projekt auswählen">
-                    <button id="tab-e46" class="project-nav-btn project-pag-btn active" data-project="e46" data-category="web" role="tab" aria-selected="true" aria-controls="slide-e46" tabindex="0">
+                    <button id="tab-coha" class="project-nav-btn project-pag-btn" data-project="coha" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-coha" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">01</span>
+                        <span class="project-pag-name">Co Ha</span>
+                    </button>
+                    <button id="tab-imkerei" class="project-nav-btn project-pag-btn" data-project="imkerei" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-imkerei" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">02</span>
+                        <span class="project-pag-name">Imkerei Feuerstein</span>
+                    </button>
+                    <button id="tab-jkentertainment" class="project-nav-btn project-pag-btn" data-project="jkentertainment" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-jkentertainment" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">03</span>
+                        <span class="project-pag-name">JK Entertainment</span>
+                    </button>
+                    <button id="tab-kayaseeds" class="project-nav-btn project-pag-btn" data-project="kayaseeds" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-kayaseeds" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">04</span>
+                        <span class="project-pag-name">Kaya Seeds</span>
+                    </button>
+                    <button id="tab-danielbrecheis" class="project-nav-btn project-pag-btn" data-project="danielbrecheis" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-danielbrecheis" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">05</span>
+                        <span class="project-pag-name">Daniel Brecheis</span>
+                    </button>
+                    <button id="tab-soundoflvke" class="project-nav-btn project-pag-btn" data-project="soundoflvke" data-mode="customers" data-category="web" role="tab" aria-selected="false" aria-controls="slide-soundoflvke" tabindex="-1" hidden>
+                        <span class="project-pag-index" aria-hidden="true">06</span>
+                        <span class="project-pag-name">Sound of Lvke</span>
+                    </button>
+
+                    <button id="tab-e46" class="project-nav-btn project-pag-btn active" data-project="e46" data-mode="own" data-category="web" role="tab" aria-selected="true" aria-controls="slide-e46" tabindex="0">
                         <span class="project-pag-index" aria-hidden="true">01</span>
                         <span class="project-pag-name">E46 Studio</span>
                     </button>
-                    <button id="tab-aicaptain" class="project-nav-btn project-pag-btn" data-project="aicaptain" data-category="web" role="tab" aria-selected="false" aria-controls="slide-aicaptain" tabindex="-1">
+                    <button id="tab-aicaptain" class="project-nav-btn project-pag-btn" data-project="aicaptain" data-mode="own" data-category="web" role="tab" aria-selected="false" aria-controls="slide-aicaptain" tabindex="-1">
                         <span class="project-pag-index" aria-hidden="true">02</span>
                         <span class="project-pag-name">AI Captain</span>
                     </button>
-                    <button id="tab-medieval" class="project-nav-btn project-pag-btn" data-project="medieval" data-category="game" role="tab" aria-selected="false" aria-controls="slide-medieval" tabindex="-1">
+                    <button id="tab-medieval" class="project-nav-btn project-pag-btn" data-project="medieval" data-mode="own" data-category="game" role="tab" aria-selected="false" aria-controls="slide-medieval" tabindex="-1">
                         <span class="project-pag-index" aria-hidden="true">03</span>
                         <span class="project-pag-name">Medieval TD</span>
                     </button>
-                    <button id="tab-shookroko" class="project-nav-btn project-pag-btn" data-project="shookroko" data-category="game" role="tab" aria-selected="false" aria-controls="slide-shookroko" tabindex="-1">
+                    <button id="tab-shookroko" class="project-nav-btn project-pag-btn" data-project="shookroko" data-mode="own" data-category="game" role="tab" aria-selected="false" aria-controls="slide-shookroko" tabindex="-1">
                         <span class="project-pag-index" aria-hidden="true">04</span>
                         <span class="project-pag-name">Shookroko</span>
                     </button>
-                    <button id="tab-dogkennel" class="project-nav-btn project-pag-btn" data-project="dogkennel" data-category="web" role="tab" aria-selected="false" aria-controls="slide-dogkennel" tabindex="-1">
+                    <button id="tab-dogkennel" class="project-nav-btn project-pag-btn" data-project="dogkennel" data-mode="own" data-category="web" role="tab" aria-selected="false" aria-controls="slide-dogkennel" tabindex="-1">
                         <span class="project-pag-index" aria-hidden="true">05</span>
                         <span class="project-pag-name">dog-kennel-online</span>
                     </button>
                 </nav>
+
+                <div class="all-projects scroll-reveal">
+                    <div class="all-projects__head">
+                        <h3 class="all-projects__title" data-i18n="projects.all.title">Alle Projekte</h3>
+                        <p class="all-projects__hint" data-i18n="projects.all.hint">Vollständige Übersicht — die Auswahl folgt dem Modus oben.</p>
+                    </div>
+
+                    <ul class="project-grid" role="list">
+                        <!-- ── Kundenprojekte ── -->
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/coha.html">
+                                <span class="project-card__name">Co Ha</span>
+                                <span class="project-card__desc" data-i18n="grid.coha.desc">Vietnamesisches Restaurant in Bruckmühl — Speisekarte, Galerie, Reservierung.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/imkerei-feuerstein.html">
+                                <span class="project-card__name">Imkerei Feuerstein</span>
+                                <span class="project-card__desc" data-i18n="grid.imkerei.desc">Honig-Onlineshop der Familienimkerei aus Elchingen.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/jkentertainment.html">
+                                <span class="project-card__name">JK Entertainment</span>
+                                <span class="project-card__desc" data-i18n="grid.jkentertainment.desc">TCG-Onlineshop mit über 4.000 Artikeln, zwei Stores in Frankfurt und Darmstadt.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/kayaseeds.html">
+                                <span class="project-card__name">Kaya Seeds</span>
+                                <span class="project-card__desc" data-i18n="grid.kayaseeds.desc">E-Commerce für eine bayerische Cannabis-Samenmarke.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">E-Commerce</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/danielbrecheis.html">
+                                <span class="project-card__name">Daniel Brecheis</span>
+                                <span class="project-card__desc" data-i18n="grid.danielbrecheis.desc">Human Bridges Consulting — HR-Coaching, Workshops, Interim-Management.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Astro</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="projects/soundoflvke.html">
+                                <span class="project-card__name">Sound of Lvke</span>
+                                <span class="project-card__desc" data-i18n="grid.soundoflvke.desc">Künstler-Website mit Audio-Player und Release-Übersicht.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Web</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <a class="project-card__link" href="https://pizza-vagen.de" target="_blank" rel="noopener noreferrer">
+                                <span class="project-card__name">Castel Del Monte</span>
+                                <span class="project-card__desc" data-i18n="grid.casteldelmonte.desc">Italienisches Restaurant in Vagen — Karte, Öffnungszeiten, Kontakt.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">HTML/CSS/JS</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Käss Dellentechnik</span>
+                                <span class="project-card__desc" data-i18n="grid.kaess.desc">Lackschadenfreie Dellenreparatur — Leistungen, Ablauf, Galerie, Kontakt.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">HTML/CSS/JS</span>
+                                <span class="project-card__status is-done" data-i18n="grid.status.done">Fertig</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Wir kaufen deine Karten</span>
+                                <span class="project-card__desc" data-i18n="grid.wkdk.desc">Ankauf-Plattform für Sammelkarten — Collectibles-Hub GmbH, Rosenheim.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Astro</span>
+                                <span class="project-card__status is-done" data-i18n="grid.status.done">Fertig</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <div class="project-card__link">
+                                <span class="project-card__name">BB-Spiele</span>
+                                <span class="project-card__desc" data-i18n="grid.bbspiele.desc">Marketing-Website für den Spiele- und Collectibles-Händler aus Rosenheim.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Astro</span>
+                                <span class="project-card__status is-done" data-i18n="grid.status.done">Fertig</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Nolte Classics</span>
+                                <span class="project-card__desc" data-i18n="grid.nolte.desc">Markenauftritt für Klassiker-Fahrzeuge.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="customers">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Jäggl</span>
+                                <span class="project-card__desc" data-i18n="grid.jaeggl.desc">Redesign eines bestehenden Firmenauftritts.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">React</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+
+                        <!-- ── Eigene Projekte ── -->
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="projects/e46-studio.html">
+                                <span class="project-card__name">E46 Studio</span>
+                                <span class="project-card__desc" data-i18n="grid.e46.desc">Desktop-App für BMW E46 Steuergeräte-Coding über serielle Schnittstelle.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Electron</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="projects/aicaptain.html">
+                                <span class="project-card__name">AI Captain</span>
+                                <span class="project-card__desc" data-i18n="grid.aicaptain.desc">KI-Agent als VS Code Extension — Code-Generierung, Debugging, Review.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">TypeScript</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="https://mittel-alte.vercel.app" target="_blank" rel="noopener noreferrer">
+                                <span class="project-card__name">Medieval Tower Defense</span>
+                                <span class="project-card__desc" data-i18n="grid.medieval.desc">Browser-Strategiespiel im Mittelalter-Setting mit eigenem Wave-System.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Browser Game</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="projects/shookroko.html">
+                                <span class="project-card__name">Shookroko</span>
+                                <span class="project-card__desc" data-i18n="grid.shookroko.desc">Action-Browsergame mit Phaser 3, eigener Game-Loop und Asset-Pipeline.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Phaser 3</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="https://e46-viola.vercel.app" target="_blank" rel="noopener noreferrer">
+                                <span class="project-card__name">E46 Viola</span>
+                                <span class="project-card__desc" data-i18n="grid.e46viola.desc">Fahrzeug-Showcase aus dem E46-Umfeld.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">HTML/CSS/JS</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <a class="project-card__link" href="https://team-kickoff.vercel.app" target="_blank" rel="noopener noreferrer">
+                                <span class="project-card__name">Team Kickoff</span>
+                                <span class="project-card__desc" data-i18n="grid.teamkickoff.desc">Interaktives Meeting-Board für neun Personen mit geteiltem Zustand.</span>
+                            </a>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Vercel Functions</span>
+                                <span class="project-card__status is-live" data-i18n="grid.status.live">Live</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">dog-kennel-online</span>
+                                <span class="project-card__desc" data-i18n="grid.dogkennel.desc">Plattform für Hundepensionen — Buchungen, Belegung, Hunde- und Halterprofile.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Web App</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Teahop</span>
+                                <span class="project-card__desc" data-i18n="grid.teahop.desc">Bio-Tee-Shop als eigenes Shopify-Theme, Online Store 2.0.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Shopify</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">TeeKompass</span>
+                                <span class="project-card__desc" data-i18n="grid.teekompass.desc">Bio-Tee-Abo mit KI-Personalisierung: Box, Bewertung, bessere nächste Box.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js &amp; Supabase</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">GLOWCAN</span>
+                                <span class="project-card__desc" data-i18n="grid.glowcan.desc">3D-gedruckter LED-Deckel für Energy-Dosen — Shopify-Theme, mobile-first.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Shopify</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Bierbrauen</span>
+                                <span class="project-card__desc" data-i18n="grid.bierbrauen.desc">Web-App rund ums Bierbrauen — Rezepte und Prozessbegleitung.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Next.js</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Albert</span>
+                                <span class="project-card__desc" data-i18n="grid.albert.desc">Evolutionssimulation mit neuronalen Netzen, plus 3D-Battle-Royale-Ableger.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Java &amp; TypeScript</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Kundenkalender</span>
+                                <span class="project-card__desc" data-i18n="grid.kundenkalender.desc">Lokaler Terminkalender als Desktop-App — Serientermine, ICS/CSV-Export.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">React &amp; Tauri</span>
+                                <span class="project-card__status is-done" data-i18n="grid.status.done">Fertig</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">Maxorchester</span>
+                                <span class="project-card__desc" data-i18n="grid.maxorchester.desc">Orchestrierung mehrerer KI-Agenten über ein gemeinsames Frontend.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">TypeScript</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">VibeIDE</span>
+                                <span class="project-card__desc" data-i18n="grid.vibeide.desc">Experimentelle Entwicklungsumgebung mit KI-gestütztem Workflow.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">TypeScript</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">MoneyDash</span>
+                                <span class="project-card__desc" data-i18n="grid.moneydash.desc">Dashboard für Finanzdaten und Auswertungen.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">TypeScript</span>
+                                <span class="project-card__status is-wip" data-i18n="grid.status.wip">In Arbeit</span>
+                            </div>
+                        </li>
+                        <li class="project-card" data-mode="own">
+                            <div class="project-card__link">
+                                <span class="project-card__name">assetkit</span>
+                                <span class="project-card__desc" data-i18n="grid.assetkit.desc">Toolchain für Spiel-Assets — Generierung, Freistellen, Normalisierung.</span>
+                            </div>
+                            <div class="project-card__meta">
+                                <span class="project-card__stack">Python</span>
+                                <span class="project-card__status is-done" data-i18n="grid.status.done">Fertig</span>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Zusammenfassung
- schaltet die Kundenprojekte im Portfolio-Slider frei
- ergänzt Filterung, Navigation, Themes und Übersetzungen für den gemeinsamen Slider
- erweitert die Portfolio-Darstellung um sechs Kundenprojekte

## Einordnung
Dieser Stand ist eine alternative `data-mode`-Implementierung. Der spätere Albert-Stand baut auf demselben Ansatz auf und enthält zusätzlich Albert, Detailseite und weitere Projektinhalte.

## Validierung
- Branch-Diff und Asset-Größen lokal geprüft
- GitHub Actions soll die statischen Referenzen und die 600-KB-Asset-Grenze prüfen